### PR TITLE
Fixed Encoding of Input Numbers to Qubits

### DIFF
--- a/Documentation.md
+++ b/Documentation.md
@@ -1,0 +1,1 @@
+This is a documentation file, here I will explain what we did in this project and how it works

--- a/Documentation.md
+++ b/Documentation.md
@@ -1,2 +1,13 @@
-**This is a documentation file, here I will explain what we did in this project and how it works**
+**Repository Overview**
+
+We will perform a multiplication operation on the IBM quantum computer, taking a simple example of multiplying two numbers. As it is suggested that for simple athematic operations using quantum computers is not an excellent choice, but we just want to check and learn how things work on a quantum computer. 
+
+**Environmental setup**
+
+**Code Structure**
+
+**Quantum Algorithm**
+
+
+
 

--- a/Documentation.md
+++ b/Documentation.md
@@ -3,8 +3,43 @@
 We will perform a multiplication operation on the IBM quantum computer, taking a simple example of multiplying two numbers. As it is suggested that for simple athematic operations using quantum computers is not an excellent choice, but we just want to check and learn how things work on a quantum computer. 
 
 **Environmental setup**
-
+We performed a simple matiplication fuunction, using IMB quantum computer plateform.
+https://quantum-computing.ibm.com/
 **Code Structure**
+**The code itself is well structured but I will explain its different parts and how they work.
+Imports**:
+
+**(1)** import qiskit: This statement imports the Qiskit library, which is used for quantum computing.
+import numpy as np: This statement imports the NumPy library, often used for numerical operations in Python.
+Function Definition:
+
+**(2)** def quantum_multiplication(multiplicand, multiplier):: This line defines a Python function named quantum_multiplication that takes two arguments: multiplicand (the first number to multiply) and multiplier (the second number to multiply).
+The function has a docstring (enclosed in triple quotes) that provides a brief description of what the function does, its arguments, and its return value.
+Initializing Quantum Registers and Circuit:
+
+**(3)** q = qiskit.QuantumRegister(4) and c = qiskit.ClassicalRegister(4): These lines create quantum and classical registers, each with 4 qubits or bits.
+circuit = qiskit.QuantumCircuit(q, c): This line initializes a quantum circuit that uses the created quantum and classical registers.
+Encoding Inputs:
+
+**(4)** circuit.x(q[0]) and circuit.x(q[1]): These lines set the first and second qubits of the quantum register to the state |1>, effectively encoding the multiplicand and multiplier as 1 in binary.
+Hadamard Gates:
+
+**(5)** circuit.h(q[0]) and circuit.h(q[1]): These lines apply Hadamard gates to the first and second qubits. Hadamard gates prepare the qubits in a superposition of states, which is a key step in quantum algorithms.
+Quantum Fourier Transform (QFT):
+
+The code attempts to create a QFT multiplication circuit. However, there is some commented-out code related to this section, and it seems there are issues with the commented-out code. The QFT is a crucial component in quantum multiplication algorithms.
+Measurement and Execution:
+
+**(6)** circuit.measure(q, c): This line adds measurements to the quantum circuit, which will be used to obtain the final result.
+job = qiskit.execute(circuit, backend=qiskit.Aer.get_backend('qasm_simulator')): This line sends the quantum circuit to a simulator backend for execution.
+result = job.result(): It retrieves the result of the quantum computation.
+Extracting the Product:
+
+**(7)** product = format(result.get_counts().get('0000', 0), '04b'): This line extracts the product from the measurement outcomes. It looks for the specific outcome '0000' (which represents the product) and converts it to its binary representation.
+Returning the Result:
+
+**(8)** return int(product, 2): This line converts the binary product back to an integer and returns it as the output of the quantum_multiplication function.
+Overall, this code appears to be an attempt to perform quantum multiplication, but it has some commented-out code and issues related to the QFT part. You may need to resolve these issues for the code to function correctly. Additionally, this code seems to be a simplified example and may not be suitable for practical multiplication of large numbers on a quantum computer. Quantum multiplication algorithms are typically more complex and specialized.
 
 **Quantum Algorithm**
 

--- a/Documentation.md
+++ b/Documentation.md
@@ -1,1 +1,2 @@
-This is a documentation file, here I will explain what we did in this project and how it works
+**This is a documentation file, here I will explain what we did in this project and how it works**
+

--- a/quantum_multiplication_v2.py
+++ b/quantum_multiplication_v2.py
@@ -13,26 +13,33 @@ def quantum_multiplication(multiplicand, multiplier):
     The product of the two numbers.
   """
 
+  # Adding these variables to clean up a little. The -2 is because of how
+  # python expresses binary numbers
+  multiplicandBinLen = len(bin(multiplicand)) - 2
+  multiplierBinLen = len(bin(multiplier)) - 2
+
   # Initialize the registers and quantum circuit.
-  q = qiskit.QuantumRegister(4)
-  c = qiskit.ClassicalRegister(4)
+  q = qiskit.QuantumRegister(8)
+  c = qiskit.ClassicalRegister(8)
   circuit = qiskit.QuantumCircuit(q, c)
 
   # Encode the values on to the Operands.
-  circuit.x(q[0])  # Set the multiplicand to |1>.
-  circuit.x(q[1])  # Set the multiplier to |1>.
+  for i in range(multiplicandBinLen):
+    print(bin(multiplicand)[len(bin(multiplicand))-1-i])
+    if int(bin(multiplicand)[len(bin(multiplicand))-1-i]) == 1:
+      circuit.x(q[i])
+
+  for i in range(multiplierBinLen):
+    print(int(bin(multiplier)[len(bin(multiplier))-1-i]))
+    if int(bin(multiplier)[len(bin(multiplier))-1-i]) == 1:
+      circuit.x(q[i + 4])
 
   # Add an Hadamard gate to each of the input qubits.
-  circuit.h(q[0])
-  circuit.h(q[1])
+  circuit.h(q)
 
   # Create the QFT multiplication circuit.
-  qft_circuit = qiskit.circuit.library.QFT(4)
-    
-  # Convert the QasmQobj object to a QuantumCircuit object.
-
-  # Combine the two circuits.
-  #circuit += qft_circuit
+  qft_circuit = qiskit.circuit.library.QFT(8)
+  
   circuit.compose(qft_circuit)
   # Measure the output qubits.
   circuit.measure(q, c)
@@ -42,7 +49,6 @@ def quantum_multiplication(multiplicand, multiplier):
   result = job.result()
 
   # The product is the binary representation of the measured state.
-  product = format(result.get_counts().get('0000', 0), '04b')
-
+  product = format(result.get_counts().get('00000000', 0), '08b')
 
   return int(product, 2)


### PR DESCRIPTION
Before the encoding was being done improperly, meaning that the register did not correctly have the numbers in binary form before performing the multiplication algorithm. Should be fixed now